### PR TITLE
index: link (almost) all content in tiles of index page

### DIFF
--- a/site/assets/ocrd.css
+++ b/site/assets/ocrd.css
@@ -28,6 +28,12 @@ h2 code, h3 code, h4 code {
 .title-image img {
     height: 300px;
 }
+.title-image-header {
+    /* padding-top: .75rem; */
+    color: #3273dc;
+    cursor: pointer;
+    text-decoration: none;
+}
 
 /* hide banner and navbar of gt guidelines / pagexml docs */
 header[role="banner"] { display: none; }

--- a/site/de/index.html
+++ b/site/de/index.html
@@ -19,26 +19,26 @@ lang-ref: home
     <div class="tile is-ancestor">
 
       <div class="tile is-parent">
-        <article class="tile is-child box">
-          <p class="title title-image">
-            <a href="dev">
+        <article class="tile is-child box has-text-centered">
+          <a href="dev">
+            <p class="title title-image">
               <img src="/assets/dev.png"/>
-            </a>
-          </p>
-          <p class="title"><a href="dev">Entwickler / Sysadmins</a></p>
-          <p class="subtitle">Finden Sie hier alles, um OCR-D in Ihrer Institution zu nutzen</p>
+            </p>
+            <p class="title title-image-header">Entwickler / Sysadmins</p>
+            <p class="subtitle">Finden Sie hier alles, um OCR-D in Ihrer Institution zu nutzen</p>
+          </a>
         </article>
       </div>
 
       <div class="tile is-parent">
-        <article class="tile is-child box">
-          <p class="title title-image">
-            <a href="use">
+        <article class="tile is-child box has-text-centered">
+          <a href="use">
+            <p class="title title-image">
               <img src="/assets/use.png"/>
-            </a>
-          </p>
-          <p class="title"><a href="use">Bibliothekare / Digitalisierungsexperten</a></p>
-          <p class="subtitle">Finden Sie hier alles, um OCR-D an Ihrer Institution einzusetzen</p>
+            </p>
+            <p class="title title-image-header">Bibliothekare / Digitalisierungsexperten</p>
+            <p class="subtitle">Finden Sie hier alles, um OCR-D an Ihrer Institution einzusetzen</p>
+          </a>
         </article>
       </div>
 

--- a/site/en/index.html
+++ b/site/en/index.html
@@ -9,36 +9,36 @@ lang-ref: home
 
     <div class="tile is-ancestor">
         <article class="tile is-child box">
-          <p class="title has-text-centered">
-            <a href="about">
+          <a href="about">
+            <p class="title has-text-centered">
               <img src="{{ "/assets/Logo-Schrift_Englisch.svg" | relative_url }}"/>
-            </a>
-          </p>
+            </p>
+          </a>
         </article>
     </div>
     <div class="tile is-ancestor">
 
       <div class="tile is-parent">
-        <article class="tile is-child box">
-          <p class="title title-image">
-            <a href="dev">
+        <article class="tile is-child box has-text-centered">
+          <a href="dev">
+            <p class="title title-image">
               <img src="/assets/dev.png"/>
-            </a>
-          </p>
-          <p class="title"><a href="dev">Developers / System Administrators</a></p>
-          <p class="subtitle">Start here if you want to contribute to OCR-D development</p>
+            </p>
+            <p class="title title-image-header">Developers / System Administrators</p>
+            <p class="subtitle">Start here if you want to contribute to OCR-D development</p>
+          </a>
         </article>
       </div>
 
       <div class="tile is-parent">
-        <article class="tile is-child box">
-          <p class="title title-image">
-            <a href="use">
+        <article class="tile is-child box has-text-centered">
+          <a href="use">
+            <p class="title title-image">
               <img src="/assets/use.png"/>
-            </a>
-          </p>
-          <p class="title"><a href="use">System Librarians / Digitization experts</a></p>
-          <p class="subtitle">Start here if you are ready to start using OCR-D in your institution</p>
+            </p>
+            <p class="title title-image-header">System Librarians / Digitization experts</p>
+            <p class="subtitle">Start here if you are ready to start using OCR-D in your institution</p>
+          </a>
         </article>
       </div>
 


### PR DESCRIPTION
before
![grafik](https://user-images.githubusercontent.com/273367/75354498-55c85400-58ad-11ea-85c2-d259b06ba6dc.png)

after

![grafik](https://user-images.githubusercontent.com/273367/75354536-62e54300-58ad-11ea-9457-aa281888ec58.png)

(centered content, all content in boxes links to `use`, `dev` and `about` resp.