### PR TITLE
user_guide/setup: use local venv dir

### DIFF
--- a/site/en/setup.md
+++ b/site/en/setup.md
@@ -270,9 +270,9 @@ sudo apt install python3 python3-venv
 
 ```sh
 # If you haven't created the venv yet:
-python3 -m venv ~/venv
+python3 -m venv venv
 # Activate the venv
-source ~/venv/bin/activate
+source venv/bin/activate
 ```
 
 Once you have activated the virtualenv, you should see `(venv)` prepended to
@@ -339,7 +339,7 @@ First, activate your venv:
 
 ```sh
 # Activate the venv
-source ~/venv/bin/activate
+source venv/bin/activate
 ```
 
 Let's segment the images in file group `OCR-D-IMG` into regions (creating a

--- a/site/en/user_guide.md
+++ b/site/en/user_guide.md
@@ -52,7 +52,7 @@ software via ocrd_all, or you should have [installed it yourself](https://packag
 installing the OCR-D-software individually. 
 
 ```sh
-source ~/venv/bin/activate
+source venv/bin/activate
 ```
 
 Once you have activated the virtualenv, you should see `(venv)` prepended to


### PR DESCRIPTION
Using a directory `~/venv` instead of just `venv` seems to confuse users.