### PR TITLE
user guide: use non-deprecated forms of ocrd workspace clone/init

### DIFF
--- a/site/en/developer-guide.md
+++ b/site/en/developer-guide.md
@@ -395,7 +395,7 @@ $WORKSPACE_DIR/mets3000.xml
 $ ocrd workspace -d $WORKSPACE_DIR find
 
 # This will not
-$ ocrd workspace -d $WORKSPACE_DIR -M mets3000.xml find
+$ ocrd workspace -d $WORKSPACE_DIR -m mets3000.xml find
 ```
 
 ### Creating an empty workspace
@@ -403,7 +403,7 @@ $ ocrd workspace -d $WORKSPACE_DIR -M mets3000.xml find
 To create an empty workspace to which you can add files, use the `workspace init` command
 
 ```sh
-$ ocrd workspace init ws1
+$ ocrd workspace -d ws1 init
 /home/ocr/ws1
 ```
 
@@ -412,7 +412,7 @@ $ ocrd workspace init ws1
 To create a workspace and save a METS file, use the `workspace clone` command:
 
 ```sh
-$ ocrd workspace clone $METS_URL new-workspace
+$ ocrd workspace -d new-workspace clone $METS_URL
 /home/ocr/new-workspace
 
 $ find new-workspace
@@ -426,7 +426,7 @@ To not only [clone the METS](#load-an-existing-mets-as-a-workspace) but also
 download the contained files, use `workspace clone` with the `--download` flag:
 
 ```sh
-$ ocrd workspace clone --download $METS_URL $WORKSPACE_DIR
+$ ocrd workspace -d $WORKSPACE_DIR clone --download $METS_URL
 
 $ find $WORKSPACE_DIR
 $WORKSPACE_DIR
@@ -520,7 +520,7 @@ specs](https://ocr-d.github.io/mets), use the `workspace validate` command:
 
 ```sh
 # Create a bare workspace
-ocrd workspace init $WORKSPACE_DIR
+ocrd workspace -d  $WORKSPACE_DIR init
 
 # Validate
 <report valid="false">

--- a/site/en/user_guide.md
+++ b/site/en/user_guide.md
@@ -123,10 +123,10 @@ can generate it with the following commands. First, you have to create a
 workspace:
 
 ```sh
-ocrd workspace init [/path/to/your/workspace] # or empty for current directory
+ocrd workspace [-d /path/to/your/workspace] init # omit `-d` for current directory
 ## alternatively using docker
 mkdir -p [/path/to/your/workspace]
-docker run --rm -u $(id -u) -v [/path/to/your/workspace]:/data -w /data -- ocrd/all:maximum ocrd workspace init /data
+docker run --rm -u $(id -u) -v [/path/to/your/workspace]:/data -w /data -- ocrd/all:maximum ocrd workspace -d /data init
 ```
 
 This should create a directory (called workspace in OCR-D) which contains a `mets.xml`.
@@ -175,9 +175,19 @@ docker run --rm -u $(id -u) -v $PWD:/data -w /data -- ocrd/all:maximum ocrd work
 If you have many pictures to be added to the METS, you can do this automatically with a for-loop:
 
 ```sh
-for i in [/path/to/your/picture/folder/in/workspace]/*.[file ending of your pictures]; do base= `basename ${i} .[file ending of your pictures]`; ocrd workspace add -G [name of picture folder in your workspace] -i OCR-D-IMG_${base} -g P_${base} -m image/[format of your pictures] ${i}; done
+FILEGRP="YOUR-FILEGRP-NAME"
+EXT=".tif"  # the actual extension of the image files
+MEDIATYPE='image/tiff'  # the actual media type of the image files
+## using local ocrd CLI
+for i in /path/to/your/picture/folder/in/workspace/*$ext; do
+  base= `basename ${i} $ext`;
+  ocrd workspace add -G $FILEGRP -i ${FILE_GRP}_${base} -g P_${base} -m $MEDIATYPE ${i};
+done
 ## alternatively using docker
-for i in [relative/path/to/your/picture/folder/in/workspace]/*.[file ending of your pictures]; do base= `basename ${i} .[file ending of your pictures]`; docker run --rm -u $(id -u) -v $PWD:/data -w /data -- ocrd/all:maximum ocrd workspace add -G [name of picture folder in your workspace] -i OCR-D-IMG_${base} -g P_${base} -m image/[format of your pictures] ${i}; done 
+for i in /path/to/your/picture/folder/in/workspace/*$ext; do
+  base= `basename ${i} $ext`;
+  docker run --rm -u $(id -u) -v $PWD:/data -w /data -- ocrd/all:maximum ocrd workspace add -G $FILEGRP -i ${FILE_GRP}_${base} -g P_${base} -m $MEDIATYPE ${i};
+done
 ```
 
 <img src="https://github.githubassets.com/images/icons/emoji/unicode/26a0.png" alt="warning" style="zoom:33%;" /> If the file names of the images starts with a number, at least one of the following characters must be placed in front of its name for parameter 'i': [a-z,A-Z,_,-] (e.g.: 'OCR-D-IMG_\_')


### PR DESCRIPTION
also makes the sample code for adding files in a for-loop more readable.