### PR TITLE
Page titles in front matter

### DIFF
--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -1,6 +1,6 @@
 <head>
   <meta charset="utf-8"/>
-  <title>{{ page.title }}</title>
+  <title>{{ page.title }} - OCR-D</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="shortcut icon" href="https://avatars0.githubusercontent.com/u/26362587?s=200&amp;v=4" />

--- a/site/en/example_mets.md
+++ b/site/en/example_mets.md
@@ -5,6 +5,7 @@ date: 2020-02-04T19:16:54+01:00
 lang: en
 lang-ref: from-novice-to-pro
 toc: true
+title: Example METS
 ---
 
 # Example METS

--- a/site/en/faq.md
+++ b/site/en/faq.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: faq
 toc: true
+title: FAQ
 ---
 # FAQ
 

--- a/site/en/imprint.md
+++ b/site/en/imprint.md
@@ -3,6 +3,7 @@ layout: page
 toc: true
 lang: en
 lang-ref: impressum
+title: Imprint
 ---
 
 # Imprint

--- a/site/en/initial-tests.md
+++ b/site/en/initial-tests.md
@@ -2,6 +2,7 @@
 layout: page
 lang-ref: initial-tests
 lang: en
+title: Results and findings of the first OCR-D test
 ---
 
 # Results and findings of the first OCR-D test

--- a/site/en/kwalitee.md
+++ b/site/en/kwalitee.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: kwalitee
 toc: true
+title: Kwalitee
 ---
 
 

--- a/site/en/models.md
+++ b/site/en/models.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: faq
 toc: true
+title: Models for OCR-D processors
 ---
 
 # Models for OCR-D processors

--- a/site/en/module-processors.md
+++ b/site/en/module-processors.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: kwalitee
 toc: true
+title: Module Processors
 ---
 
 {%- for repo in site.data.ocrd-repo -%}

--- a/site/en/module-projects.md
+++ b/site/en/module-projects.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: module-projects
 toc: true
+title: Module Projects
 ---
 
 # Module Projects

--- a/site/en/ocrd-gt-repo.md
+++ b/site/en/ocrd-gt-repo.md
@@ -4,6 +4,7 @@ author: Volker Hartmann
 toc: true
 lang: en
 lang-ref: ocrd-gt-repo
+title: Working with OCR-D-(Ground-Truth)-Repository
 ---
 # Working with OCR-D-(Ground-Truth)-Repository 
 

--- a/site/en/platforms.md
+++ b/site/en/platforms.md
@@ -2,6 +2,7 @@
 layout: page
 lang: en
 lang-ref: platforms
+title: OCR-D Platforms
 ---
 # OCR-D Platforms
 

--- a/site/en/project-summary.md
+++ b/site/en/project-summary.md
@@ -3,6 +3,7 @@ layout: page
 toc: true
 lang: en
 lang-ref: brief-description
+title: Brief Description & Project Goals
 ---
 # Brief Description & Project Goals
 

--- a/site/en/project.md
+++ b/site/en/project.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 lang: en
+title: The OCR-D Project
 ---
 
 # The OCR-D Project

--- a/site/en/publications.md
+++ b/site/en/publications.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 toc: true
 lang-ref: publications
+title: Publications
 ---
 
 ## Publications

--- a/site/en/setup.md
+++ b/site/en/setup.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: https://translate.google.com/translate?hl=&sl=en&tl=de&u=https%3A%2F%2Focr-d.de%2Fen%2Fsetup
 toc: true
+title: OCR-D setup guide
 ---
 
 # OCR-D setup guide

--- a/site/en/spec/CHANGELOG.md
+++ b/site/en/spec/CHANGELOG.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: CHANGELOG.md
 toc: true
+title: Change Log
 ---
 
 Change Log

--- a/site/en/spec/cli.md
+++ b/site/en/spec/cli.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: cli.md
 toc: true
+title: Command Line Interface (CLI)
 ---
 
 # Command Line Interface (CLI)

--- a/site/en/spec/docker.md
+++ b/site/en/spec/docker.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: docker.md
 toc: true
+title: Dockerfile provided by MP
 ---
 
 # Dockerfile provided by MP

--- a/site/en/spec/glossary.md
+++ b/site/en/spec/glossary.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: glossary.md
 toc: true
+title: OCR-D Glossary
 ---
 
 # OCR-D Glossary

--- a/site/en/spec/index.md
+++ b/site/en/spec/index.md
@@ -2,6 +2,7 @@
 layout: page
 lang: en
 lang-ref: spec
+title: Specifications
 ---
 
 <div class="tile is-ancestor">

--- a/site/en/spec/intro.md
+++ b/site/en/spec/intro.md
@@ -2,6 +2,7 @@
 layout: page
 lang: en
 lang-ref: spec-intro
+title: OCR-D Specs Overview
 ---
 
 # OCR-D Specs Overview

--- a/site/en/spec/logging.md
+++ b/site/en/spec/logging.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: logging.md
 toc: true
+title: Conventions for LOGGING
 ---
 
 # THIS IS JUST A FIRST DRAFT!

--- a/site/en/spec/mets.md
+++ b/site/en/spec/mets.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: mets.md
 toc: true
+title: Requirements on handling METS/PAGE
 ---
 
 # Requirements on handling METS/PAGE

--- a/site/en/spec/ocrd_tool.md
+++ b/site/en/spec/ocrd_tool.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: ocrd_tool.md
 toc: true
+title: ocrd-tool.json
 ---
 
 # ocrd-tool.json

--- a/site/en/spec/ocrd_zip.md
+++ b/site/en/spec/ocrd_zip.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: ocrd_zip.md
 toc: true
+title: OCRD-ZIP
 ---
 
 # OCRD-ZIP

--- a/site/en/spec/page.md
+++ b/site/en/spec/page.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: page.md
 toc: true
+title: Conventions for PAGE
 ---
 
 # Conventions for PAGE

--- a/site/en/spec/provenance.md
+++ b/site/en/spec/provenance.md
@@ -3,6 +3,7 @@ layout: page
 lang: en
 lang-ref: provenance.md
 toc: true
+title: Provenance
 ---
 
 # Provenance

--- a/site/en/user_guide.md
+++ b/site/en/user_guide.md
@@ -5,6 +5,7 @@ date: 2020-02-04T19:16:54+01:00
 lang: en
 lang-ref: https://translate.google.com/translate?hl=&sl=en&tl=de&u=https%3A%2F%2Focr-d.de%2Fen%2Fuser_guide
 toc: true
+title: User Guide for Non-IT Users
 ---
 
 # User Guide for Non-IT Users

--- a/site/en/user_survey.md
+++ b/site/en/user_survey.md
@@ -2,6 +2,7 @@
 layout: page
 lang-ref: user survey
 lang: en
+title: Survey concerning usage of OCR texts
 ---
 
 # Survey concerning usage of OCR texts


### PR DESCRIPTION
# Cosmetic changes

I took the liberty of adding the `title` fields to the front matter of the pages, which will show up in the `<head><title></title></head>` field. This makes it easier to distinguish the several tabs I might have open for reference.
It should also help the SEO and with that, make it easier to find the correct page.

The titles are currently based on the first H1 header found on the page.

The second commit adds ' - OCR-D' to the end of all pages, which is a common practice, though not necessary, so cherry-pick if you want.