### PR TITLE
revert #216 in light of OCR-D/ocrd-website#215

### DIFF
--- a/site/en/workflows.md
+++ b/site/en/workflows.md
@@ -551,7 +551,6 @@ processors with calls to `ocrd-tesserocr-recognize` with specific parameters:
 
 * `segmentation_level` determines the *highest level* to segment. Use `"none"` to disable segmentation altogether, i.e. only recognize existing segments.
 * `textequiv_level` determines the *lowest level* to segment. Use `"none"` to segment until the lowest level (`"glyph"`) and disable recognition altogether, only analyse layout.
-Be aware that if you use `-P segmentation_level word -P textequiv_level word` with `ocrd-tesserocr-recognize`, it will resegment the words anyway.
 * `model` determines the model to use for text recognition. Use `""` or do not set at all to disable recognition, i.e. only analyse layout.
 
 Examples:


### PR DESCRIPTION
@bertsky [clarified](https://github.com/OCR-D/ocrd-website/issues/215#issuecomment-848064422) that the issue is not resegmentation of words but that information is lost when serializing and deserializing the segmentation results when doing segmentation and recognition as separate steps. We could still document this but the current sentence is well-intentioned but misleading.