### PR TITLE
calendar: use local time so as not to confuse rrule

### DIFF
--- a/site/ocrd-events.json
+++ b/site/ocrd-events.json
@@ -4,7 +4,8 @@
     "rrule": {
       "freq": "weekly",
       "interval": 2,
-      "dtstart": "2021-10-13T12:00:00Z"
+      "dtstart": "2021-10-13T14:00:00",
+      "tzid": "Europe/Berlin"
     }
   },
   {
@@ -12,7 +13,8 @@
     "rrule": {
       "freq": "weekly",
       "interval": 2,
-      "dtstart": "2021-10-14T11:00:00Z"
+      "dtstart": "2021-10-14T13:00:00",
+      "tzid": "Europe/Berlin"
     }
   },
   {
@@ -22,7 +24,8 @@
       "interval": 1,
       "wkst": "fr",
       "bysetpos": [1],
-      "dtstart": "2021-11-05T08:00:00Z"
+      "dtstart": "2021-11-05T10:00:00",
+      "tzid": "Europe/Berlin"
     }
   }
 ]


### PR DESCRIPTION
This change should fix the problem with DST leading to off-by-one error in the hours. cf. http://ocr-d.kba.cloud:4040/ocrd-calendar.html