### PR TITLE
make shortcuts ocr-d.de/goto/{{ shortcut }} -> {{ url }}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,3 +189,14 @@ site/en/workflows.md: site/en/workflows.src.md $(wildcard repo/ocrd-website.wiki
 	@echo "!!! Manually edit site/en/workflows.md before comitting!"
 	@echo "!!!"
 
+shortcuts:
+	mkdir -p site/goto
+	while read line;do \
+		slug_and_url=($${line}); \
+		slug=$${slug_and_url[0]}; \
+		url=$${slug_and_url[1]}; \
+		dir=site/goto/$$slug; \
+		index_html=$$dir/index.html; \
+		mkdir -p $$dir; \
+		sed "s,{{ url }},$$url,g" shortcuts.template.html > $$index_html; \
+	done < shortcuts.txt

--- a/README.md
+++ b/README.md
@@ -184,3 +184,10 @@ or simply run both at once:
 make build-site deploy
 ```
 
+
+### URL Shortcuts
+
+To add a shortcut to use the `https://ocr-d.de/goto/foo` mechanism:
+
+* Add a line consisting of the shortcut name, a space charater and the URL to `shortcuts.txt`
+* `make shortcuts`

--- a/shortcuts.template.html
+++ b/shortcuts.template.html
@@ -6,7 +6,7 @@
     <title>Redirecting to {{ url }}</title>
   </head>
   <body>
-    <h1>Redirecting to {{ url }}</h1>
+    <h1>Redirecting to <a href="{{ url }}">{{ url }}</a></h1>
     <script>
       const u = window.location.href
       window.location.href = '{{ url }}'

--- a/shortcuts.template.html
+++ b/shortcuts.template.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Redirecting to {{ url }}</title>
+  </head>
+  <body>
+    <h1>Redirecting to {{ url }}</h1>
+    <script>
+      const u = window.location.href
+      window.location.href = '{{ url }}'
+    </script>
+  </body>
+</html>

--- a/shortcuts.txt
+++ b/shortcuts.txt
@@ -1,0 +1,9 @@
+gt-guidelines /en/gh-guidelines/trans
+gt-repo https://ocr-d-repo.scc.kit.edu/api/v1/metastore/bagit
+gt-call https://pad.gwdg.de/3mceR3VcSUOJSFVnazaiig
+tech-call https://pad.gwdg.de/75dyxG6gS-e0Q04_fpm-ng
+apidocs /core
+wiki https://github.com/OCR-D/ocrd-website/wiki
+calendar /en/community
+gitter https://gitter.im/OCR-D/Lobby
+zenhub https://app.zenhub.com/workspaces/ocr-d-619ce2730fdbba0010685240/board

--- a/site/goto/apidocs/index.html
+++ b/site/goto/apidocs/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Redirecting to /core</title>
+  </head>
+  <body>
+    <h1>Redirecting to /core</h1>
+    <script>
+      const u = window.location.href
+      window.location.href = '/core'
+    </script>
+  </body>
+</html>

--- a/site/goto/apidocs/index.html
+++ b/site/goto/apidocs/index.html
@@ -6,7 +6,7 @@
     <title>Redirecting to /core</title>
   </head>
   <body>
-    <h1>Redirecting to /core</h1>
+    <h1>Redirecting to <a href="/core">/core</a></h1>
     <script>
       const u = window.location.href
       window.location.href = '/core'

--- a/site/goto/calendar/index.html
+++ b/site/goto/calendar/index.html
@@ -6,7 +6,7 @@
     <title>Redirecting to /en/community</title>
   </head>
   <body>
-    <h1>Redirecting to /en/community</h1>
+    <h1>Redirecting to <a href="/en/community">/en/community</a></h1>
     <script>
       const u = window.location.href
       window.location.href = '/en/community'

--- a/site/goto/calendar/index.html
+++ b/site/goto/calendar/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Redirecting to /en/community</title>
+  </head>
+  <body>
+    <h1>Redirecting to /en/community</h1>
+    <script>
+      const u = window.location.href
+      window.location.href = '/en/community'
+    </script>
+  </body>
+</html>

--- a/site/goto/gitter/index.html
+++ b/site/goto/gitter/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Redirecting to https://gitter.im/OCR-D/Lobby</title>
+  </head>
+  <body>
+    <h1>Redirecting to https://gitter.im/OCR-D/Lobby</h1>
+    <script>
+      const u = window.location.href
+      window.location.href = 'https://gitter.im/OCR-D/Lobby'
+    </script>
+  </body>
+</html>

--- a/site/goto/gitter/index.html
+++ b/site/goto/gitter/index.html
@@ -6,7 +6,7 @@
     <title>Redirecting to https://gitter.im/OCR-D/Lobby</title>
   </head>
   <body>
-    <h1>Redirecting to https://gitter.im/OCR-D/Lobby</h1>
+    <h1>Redirecting to <a href="https://gitter.im/OCR-D/Lobby">https://gitter.im/OCR-D/Lobby</a></h1>
     <script>
       const u = window.location.href
       window.location.href = 'https://gitter.im/OCR-D/Lobby'

--- a/site/goto/gt-call/index.html
+++ b/site/goto/gt-call/index.html
@@ -6,7 +6,7 @@
     <title>Redirecting to https://pad.gwdg.de/3mceR3VcSUOJSFVnazaiig</title>
   </head>
   <body>
-    <h1>Redirecting to https://pad.gwdg.de/3mceR3VcSUOJSFVnazaiig</h1>
+    <h1>Redirecting to <a href="https://pad.gwdg.de/3mceR3VcSUOJSFVnazaiig">https://pad.gwdg.de/3mceR3VcSUOJSFVnazaiig</a></h1>
     <script>
       const u = window.location.href
       window.location.href = 'https://pad.gwdg.de/3mceR3VcSUOJSFVnazaiig'

--- a/site/goto/gt-call/index.html
+++ b/site/goto/gt-call/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Redirecting to https://pad.gwdg.de/3mceR3VcSUOJSFVnazaiig</title>
+  </head>
+  <body>
+    <h1>Redirecting to https://pad.gwdg.de/3mceR3VcSUOJSFVnazaiig</h1>
+    <script>
+      const u = window.location.href
+      window.location.href = 'https://pad.gwdg.de/3mceR3VcSUOJSFVnazaiig'
+    </script>
+  </body>
+</html>

--- a/site/goto/gt-guidelines/index.html
+++ b/site/goto/gt-guidelines/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Redirecting to /en/gh-guidelines/trans</title>
+  </head>
+  <body>
+    <h1>Redirecting to /en/gh-guidelines/trans</h1>
+    <script>
+      const u = window.location.href
+      window.location.href = '/en/gh-guidelines/trans'
+    </script>
+  </body>
+</html>

--- a/site/goto/gt-guidelines/index.html
+++ b/site/goto/gt-guidelines/index.html
@@ -6,7 +6,7 @@
     <title>Redirecting to /en/gh-guidelines/trans</title>
   </head>
   <body>
-    <h1>Redirecting to /en/gh-guidelines/trans</h1>
+    <h1>Redirecting to <a href="/en/gh-guidelines/trans">/en/gh-guidelines/trans</a></h1>
     <script>
       const u = window.location.href
       window.location.href = '/en/gh-guidelines/trans'

--- a/site/goto/gt-repo/index.html
+++ b/site/goto/gt-repo/index.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
-    <title>Redirecting to https://github.com/OCR-D/core/pull/676</title>
+    <title>Redirecting to https://ocr-d-repo.scc.kit.edu/api/v1/metastore/bagit</title>
   </head>
   <body>
-    <h1>Redirecting to https://github.com/OCR-D/core/pull/676</h1>
+    <h1>Redirecting to <a href="https://ocr-d-repo.scc.kit.edu/api/v1/metastore/bagit">https://ocr-d-repo.scc.kit.edu/api/v1/metastore/bagit</a></h1>
     <script>
       const u = window.location.href
-      window.location.href = 'https://github.com/OCR-D/core/pull/676'
+      window.location.href = 'https://ocr-d-repo.scc.kit.edu/api/v1/metastore/bagit'
     </script>
   </body>
 </html>

--- a/site/goto/gt-repo/index.html
+++ b/site/goto/gt-repo/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Redirecting to https://github.com/OCR-D/core/pull/676</title>
+  </head>
+  <body>
+    <h1>Redirecting to https://github.com/OCR-D/core/pull/676</h1>
+    <script>
+      const u = window.location.href
+      window.location.href = 'https://github.com/OCR-D/core/pull/676'
+    </script>
+  </body>
+</html>

--- a/site/goto/tech-call/index.html
+++ b/site/goto/tech-call/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Redirecting to https://pad.gwdg.de/75dyxG6gS-e0Q04_fpm-ng</title>
+  </head>
+  <body>
+    <h1>Redirecting to https://pad.gwdg.de/75dyxG6gS-e0Q04_fpm-ng</h1>
+    <script>
+      const u = window.location.href
+      window.location.href = 'https://pad.gwdg.de/75dyxG6gS-e0Q04_fpm-ng'
+    </script>
+  </body>
+</html>

--- a/site/goto/tech-call/index.html
+++ b/site/goto/tech-call/index.html
@@ -6,7 +6,7 @@
     <title>Redirecting to https://pad.gwdg.de/75dyxG6gS-e0Q04_fpm-ng</title>
   </head>
   <body>
-    <h1>Redirecting to https://pad.gwdg.de/75dyxG6gS-e0Q04_fpm-ng</h1>
+    <h1>Redirecting to <a href="https://pad.gwdg.de/75dyxG6gS-e0Q04_fpm-ng">https://pad.gwdg.de/75dyxG6gS-e0Q04_fpm-ng</a></h1>
     <script>
       const u = window.location.href
       window.location.href = 'https://pad.gwdg.de/75dyxG6gS-e0Q04_fpm-ng'

--- a/site/goto/wiki/index.html
+++ b/site/goto/wiki/index.html
@@ -6,7 +6,7 @@
     <title>Redirecting to https://github.com/OCR-D/ocrd-website/wiki</title>
   </head>
   <body>
-    <h1>Redirecting to https://github.com/OCR-D/ocrd-website/wiki</h1>
+    <h1>Redirecting to <a href="https://github.com/OCR-D/ocrd-website/wiki">https://github.com/OCR-D/ocrd-website/wiki</a></h1>
     <script>
       const u = window.location.href
       window.location.href = 'https://github.com/OCR-D/ocrd-website/wiki'

--- a/site/goto/wiki/index.html
+++ b/site/goto/wiki/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Redirecting to https://github.com/OCR-D/ocrd-website/wiki</title>
+  </head>
+  <body>
+    <h1>Redirecting to https://github.com/OCR-D/ocrd-website/wiki</h1>
+    <script>
+      const u = window.location.href
+      window.location.href = 'https://github.com/OCR-D/ocrd-website/wiki'
+    </script>
+  </body>
+</html>

--- a/site/goto/zenhub/index.html
+++ b/site/goto/zenhub/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Redirecting to https://app.zenhub.com/workspaces/ocr-d-619ce2730fdbba0010685240/board</title>
+  </head>
+  <body>
+    <h1>Redirecting to https://app.zenhub.com/workspaces/ocr-d-619ce2730fdbba0010685240/board</h1>
+    <script>
+      const u = window.location.href
+      window.location.href = 'https://app.zenhub.com/workspaces/ocr-d-619ce2730fdbba0010685240/board'
+    </script>
+  </body>
+</html>

--- a/site/goto/zenhub/index.html
+++ b/site/goto/zenhub/index.html
@@ -6,7 +6,7 @@
     <title>Redirecting to https://app.zenhub.com/workspaces/ocr-d-619ce2730fdbba0010685240/board</title>
   </head>
   <body>
-    <h1>Redirecting to https://app.zenhub.com/workspaces/ocr-d-619ce2730fdbba0010685240/board</h1>
+    <h1>Redirecting to <a href="https://app.zenhub.com/workspaces/ocr-d-619ce2730fdbba0010685240/board">https://app.zenhub.com/workspaces/ocr-d-619ce2730fdbba0010685240/board</a></h1>
     <script>
       const u = window.location.href
       window.location.href = 'https://app.zenhub.com/workspaces/ocr-d-619ce2730fdbba0010685240/board'


### PR DESCRIPTION
Since we use various platforms for different purposes (GitHub, gitter, GitHub Wiki, HedgeDoc...), it can be difficult to remember all those URLs. This PR implements a mechanism to create shortcuts for those URLs, by creating redirecting HTML pages which can be accessed in the browser as `https://ocr-d.de/goto/{{ shorrtcut }}`.

For example, `https://ocr-d.de/goto/gt-call` will redirect to `https://pad.gwdg.de/3mceR3VcSUOJSFVnazaiig`.

This is easy to extend by adding lines to `shortcuts.txt`, e.g. adding

```
foo https://example.org
```

will create a shortcut `https://ocr-d.de/goto/foo` will redirect to `https://example.org`.