### PR TITLE
user_guide: proper notation for ocrd workspace -d, fix shell script snippets

### DIFF
--- a/site/en/user_guide.md
+++ b/site/en/user_guide.md
@@ -98,7 +98,7 @@ resolution. Optionally, you can specify to only load the file group needed:
 List all existing groups:
 
 ```sh
-ocrd workspace -d [/path/to/your/workspace] list-group
+ocrd workspace [-d /path/to/your/workspace] list-group
 ## alternatively using docker
 docker run --rm -u $(id -u) -v $PWD:/data -w /data -- ocrd/all:maximum ocrd workspace -d /data list-group
 ```
@@ -109,7 +109,7 @@ PRESENTATION, MAX.
 Download all files of one group:
 
 ```sh
-ocrd workspace -d [/path/to/your/workspace] find --file-grp [selected file group] --download
+ocrd workspace [-d /path/to/your/workspace] find --file-grp [selected file group] --download
 ## alternatively using docker
 docker run --rm -u $(id -u) -v $PWD:/data -w /data -- ocrd/all:maximum ocrd workspace -d /data find --file-grp [selected file group] --download
 ```
@@ -181,12 +181,12 @@ EXT=".tif"  # the actual extension of the image files
 MEDIATYPE='image/tiff'  # the actual media type of the image files
 ## using local ocrd CLI
 for i in /path/to/your/picture/folder/in/workspace/*$EXT; do
-  base= `basename ${i} $EXT`;
+  base=`basename ${i} $EXT`;
   ocrd workspace add -G $FILEGRP -i ${FILEGRP}_${base} -g P_${base} -m $MEDIATYPE ${i};
 done
 ## alternatively using docker
 for i in /path/to/your/picture/folder/in/workspace/*$EXT; do
-  base= `basename ${i} $EXT`;
+  base=`basename ${i} $EXT`;
   docker run --rm -u $(id -u) -v $PWD:/data -w /data -- ocrd/all:maximum ocrd workspace add -G $FILEGRP -i ${FILEGRP}_${base} -g P_${base} -m $MEDIATYPE ${i};
 done
 ```


### PR DESCRIPTION
from https://github.com/OCR-D/ocr-d.github.io/pull/26/#issue-1149494084

> * No space must follow after the assignment operator '=' in bash scripts. That breaks the script in the code blocks.
> * The options (e.g. -d) should be consistent in the entire documentation to make it easier to follow.
>   Note: I fixed only some not all of them. Maybe there are other occurrences of such inconsistencies.

