### PR TITLE
Update process example to be copy-pastable

### DIFF
--- a/site/en/workflows.md
+++ b/site/en/workflows.md
@@ -1602,7 +1602,7 @@ results by configuring a more granular workflow like e.g. the
 ### Example with ocrd-process
 
 ```sh
-ocrd process "tesserocr-recognize -P segmentation_level region -P textequiv_level word -P find_tables true -P model GT4HistOCR_50000000.997_191951 -I OCR-D-IMG -O OUTPUT"
+ocrd process "tesserocr-recognize -P segmentation_level region -P find_tables true -P find_staves false -P model Fraktur_GT4HistOCR -I OCR-D-IMG -O OCR-D-OCR"
 ```
 
 ## Best results for selected pages

--- a/site/en/workflows.md
+++ b/site/en/workflows.md
@@ -1602,7 +1602,7 @@ results by configuring a more granular workflow like e.g. the
 ### Example with ocrd-process
 
 ```sh
-ocrd process "tesserocr-recognize -P segmentation_level region -P textequiv_level word -P find_tables true -P model GT4HistOCR_50000000.997_191951"
+ocrd process "tesserocr-recognize -P segmentation_level region -P textequiv_level word -P find_tables true -P model GT4HistOCR_50000000.997_191951 -I OCR-D-IMG -O OUTPUT"
 ```
 
 ## Best results for selected pages


### PR DESCRIPTION
While trying to execute the example process from the guide it threw errors about missing input/output parameters. The workspace was taken from [https://github.com/OCR-D/assets/tree/master/data/kant_aufklaerung_1784/data](assets). So new users might be confused when they copy paste this example command and it fails. 